### PR TITLE
Add user update functionality (excluding session update)

### DIFF
--- a/src/main/java/com/petstylelab/groomersunite/domain/user/User.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/User.java
@@ -44,4 +44,12 @@ public class User extends BaseEntity {
         this.registrationDate = registrationDate;
     }
 
+
+    public void modifyNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void modifyPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/petstylelab/groomersunite/domain/user/User.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/User.java
@@ -46,10 +46,14 @@ public class User extends BaseEntity {
 
 
     public void modifyNickname(String nickname) {
-        this.nickname = nickname;
+        if (StringUtils.hasText(nickname)) {
+            this.nickname = nickname;
+        }
     }
 
     public void modifyPassword(String password) {
-        this.password = password;
+        if (StringUtils.hasText(password)) {
+            this.password = password;
+        }
     }
 }

--- a/src/main/java/com/petstylelab/groomersunite/domain/user/UserCommand.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/UserCommand.java
@@ -50,6 +50,7 @@ public class UserCommand {
         private final String currentPassword;
         private final String newPassword;
 
+        @Builder
         public ModifyUserRequest(
                 String nickname,
                 String loginId,

--- a/src/main/java/com/petstylelab/groomersunite/domain/user/UserReader.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/UserReader.java
@@ -1,4 +1,5 @@
 package com.petstylelab.groomersunite.domain.user;
 
 public interface UserReader {
+    User findByLoginId(String loginId);
 }

--- a/src/main/java/com/petstylelab/groomersunite/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/UserServiceImpl.java
@@ -20,9 +20,9 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserInfo registerUser(UserCommand.RegisterUserRequest request) {
         userValidator.checkRegisterUser(request);
-        var encodedPassword = passwordEncoder.encode(request.getPassword());
-        var initUser = request.toEntity(encodedPassword, Role.NORMAL, LocalDate.now());
-        var user = userStore.storeUser(initUser);
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        User initUser = request.toEntity(encodedPassword, Role.NORMAL, LocalDate.now());
+        User user = userStore.storeUser(initUser);
         return new UserInfo(user);
     }
 
@@ -30,7 +30,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserInfo modifyUser(UserCommand.ModifyUserRequest request) {
         userValidator.checkModifyUser(request);
-        var user = userReader.findByLoginId(request.getLoginId());
+        User user = userReader.findByLoginId(request.getLoginId());
         user.modifyNickname(request.getNickname());
         user.modifyPassword(request.getNewPassword());
         return new UserInfo(user);

--- a/src/main/java/com/petstylelab/groomersunite/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/UserServiceImpl.java
@@ -14,6 +14,7 @@ public class UserServiceImpl implements UserService {
     private final UserValidator userValidator;
     private final UserStore userStore;
     private final PasswordEncoder passwordEncoder;
+    private final UserReader userReader;
 
     @Override
     @Transactional
@@ -26,8 +27,13 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public UserInfo modifyUser(UserCommand.ModifyUserRequest request) {
-        return null;
+        userValidator.checkModifyUser(request);
+        var user = userReader.findByLoginId(request.getLoginId());
+        user.modifyNickname(request.getNickname());
+        user.modifyPassword(request.getNewPassword());
+        return new UserInfo(user);
     }
 
     @Override

--- a/src/main/java/com/petstylelab/groomersunite/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/UserServiceImpl.java
@@ -31,8 +31,9 @@ public class UserServiceImpl implements UserService {
     public UserInfo modifyUser(UserCommand.ModifyUserRequest request) {
         userValidator.checkModifyUser(request);
         User user = userReader.findByLoginId(request.getLoginId());
+        String encodedPassword = passwordEncoder.encode(request.getCurrentPassword());
         user.modifyNickname(request.getNickname());
-        user.modifyPassword(request.getNewPassword());
+        user.modifyPassword(encodedPassword);
         return new UserInfo(user);
     }
 

--- a/src/main/java/com/petstylelab/groomersunite/domain/user/UserValidator.java
+++ b/src/main/java/com/petstylelab/groomersunite/domain/user/UserValidator.java
@@ -3,4 +3,6 @@ package com.petstylelab.groomersunite.domain.user;
 public interface UserValidator {
 
     void checkRegisterUser(UserCommand.RegisterUserRequest request);
+
+    void checkModifyUser(UserCommand.ModifyUserRequest request);
 }

--- a/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserJpaReader.java
+++ b/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserJpaReader.java
@@ -1,8 +1,20 @@
 package com.petstylelab.groomersunite.infrastructure.user;
 
+import com.petstylelab.groomersunite.domain.user.User;
 import com.petstylelab.groomersunite.domain.user.UserReader;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class UserJpaReader implements UserReader {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public User findByLoginId(String loginId) {
+        return userJpaRepository.findByLoginId(loginId)
+                .orElseThrow(EntityNotFoundException::new);
+    }
 }

--- a/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserValidatorImpl.java
+++ b/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserValidatorImpl.java
@@ -1,5 +1,6 @@
 package com.petstylelab.groomersunite.infrastructure.user;
 
+import com.petstylelab.groomersunite.domain.user.User;
 import com.petstylelab.groomersunite.domain.user.UserCommand;
 import com.petstylelab.groomersunite.domain.user.UserReader;
 import com.petstylelab.groomersunite.domain.user.UserValidator;
@@ -57,7 +58,7 @@ public class UserValidatorImpl implements UserValidator {
     }
 
     private void checkMatchLoginIdPassword(String loginId, String password) {
-        var user = userReader.findByLoginId(loginId);
+        User user = userReader.findByLoginId(loginId);
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new RuntimeException("비밀번호가 일치하지 않습니다.");
         }

--- a/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserValidatorImpl.java
+++ b/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserValidatorImpl.java
@@ -26,7 +26,6 @@ public class UserValidatorImpl implements UserValidator {
     public void checkModifyUser(UserCommand.ModifyUserRequest request) {
         checkMatchLoginIdPassword(request.getLoginId(), request.getCurrentPassword());
         checkPasswordNotSame(request.getCurrentPassword(), request.getNewPassword());
-        checkDuplicateNickname(request.getNickname());
     }
 
     private void checkDuplicateNickname(String nickname) {

--- a/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserValidatorImpl.java
+++ b/src/main/java/com/petstylelab/groomersunite/infrastructure/user/UserValidatorImpl.java
@@ -1,8 +1,10 @@
 package com.petstylelab.groomersunite.infrastructure.user;
 
 import com.petstylelab.groomersunite.domain.user.UserCommand;
+import com.petstylelab.groomersunite.domain.user.UserReader;
 import com.petstylelab.groomersunite.domain.user.UserValidator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -10,6 +12,8 @@ import org.springframework.stereotype.Component;
 public class UserValidatorImpl implements UserValidator {
 
     private final UserJpaRepository userJpaRepository;
+    private final UserReader userReader;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public void checkRegisterUser(UserCommand.RegisterUserRequest request) {
@@ -18,7 +22,12 @@ public class UserValidatorImpl implements UserValidator {
         checkDuplicateNickname(request.getNickname());
     }
 
-
+    @Override
+    public void checkModifyUser(UserCommand.ModifyUserRequest request) {
+        checkMatchLoginIdPassword(request.getLoginId(), request.getCurrentPassword());
+        checkPasswordNotSame(request.getCurrentPassword(), request.getNewPassword());
+        checkDuplicateNickname(request.getNickname());
+    }
 
     private void checkDuplicateNickname(String nickname) {
         userJpaRepository.findByNickname(nickname)
@@ -40,5 +49,18 @@ public class UserValidatorImpl implements UserValidator {
                 .ifPresent(user -> {
                     throw new RuntimeException("이미 존재하는 loginId 입니다.");
                 });
+    }
+
+    private void checkPasswordNotSame(String currentPassword, String newPassword) {
+        if (currentPassword.equals(newPassword)) {
+            throw new RuntimeException("현재 비밀번호와 새 비밀번호는 동일할 수 없습니다.");
+        }
+    }
+
+    private void checkMatchLoginIdPassword(String loginId, String password) {
+        var user = userReader.findByLoginId(loginId);
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/petstylelab/groomersunite/interfaces/user/UserApiController.java
+++ b/src/main/java/com/petstylelab/groomersunite/interfaces/user/UserApiController.java
@@ -6,6 +6,7 @@ import com.petstylelab.groomersunite.domain.user.UserInfo;
 import com.petstylelab.groomersunite.domain.user.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +22,15 @@ public class UserApiController {
         UserCommand.RegisterUserRequest command = request.toCommand();
         UserInfo userInfo = userService.registerUser(command);
         UserDto.RegisterResponse response = new UserDto.RegisterResponse(userInfo);
+
+        return CommonResponse.success(response);
+    }
+
+    @PatchMapping("/users")
+    public CommonResponse<UserDto.ModifyUserResponse> modifyUser(@RequestBody @Valid UserDto.ModifyUserRequest request) {
+        UserCommand.ModifyUserRequest command = request.toCommand();
+        UserInfo userInfo = userService.modifyUser(command);
+        UserDto.ModifyUserResponse response = new UserDto.ModifyUserResponse(userInfo);
 
         return CommonResponse.success(response);
     }

--- a/src/main/java/com/petstylelab/groomersunite/interfaces/user/UserApiController.java
+++ b/src/main/java/com/petstylelab/groomersunite/interfaces/user/UserApiController.java
@@ -1,6 +1,8 @@
 package com.petstylelab.groomersunite.interfaces.user;
 
 import com.petstylelab.groomersunite.common.response.CommonResponse;
+import com.petstylelab.groomersunite.domain.user.UserCommand;
+import com.petstylelab.groomersunite.domain.user.UserInfo;
 import com.petstylelab.groomersunite.domain.user.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +18,9 @@ public class UserApiController {
 
     @PostMapping("/users")
     public CommonResponse<UserDto.RegisterResponse> registerUser(@RequestBody @Valid UserDto.RegisterRequest request) {
-        var command = request.toCommand();
-        var userInfo = userService.registerUser(command);
-        var response = new UserDto.RegisterResponse(userInfo);
+        UserCommand.RegisterUserRequest command = request.toCommand();
+        UserInfo userInfo = userService.registerUser(command);
+        UserDto.RegisterResponse response = new UserDto.RegisterResponse(userInfo);
 
         return CommonResponse.success(response);
     }

--- a/src/main/java/com/petstylelab/groomersunite/interfaces/user/UserDto.java
+++ b/src/main/java/com/petstylelab/groomersunite/interfaces/user/UserDto.java
@@ -62,4 +62,59 @@ public class UserDto {
             this.registrationDate = userInfo.getRegistrationDate();
         }
     }
+    @Getter
+    @ToString
+    public static class ModifyUserRequest {
+
+        @NotBlank(message = "loginId는 필수값입니다.")
+        @Size(min = 5, max = 15, message = "loginId는 최소 5자, 최대 15자이어야 합니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "loginId는 영문자와 숫자만 허용됩니다.")
+        private String loginId;
+
+        @NotBlank(message = "nickname은 필수값입니다")
+        @Size(min = 2, max = 8, message = "nickname은 최소 2글자, 최대 8글자 입니다.")
+        private String nickname;
+
+        @NotBlank(message = "currentPassword는 필수값입니다")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$",
+                message = "비밀번호는 '숫자', '문자', '특수문자'를 최소 1개 이상 포함하며, 8자에서 16자까지 허용됩니다.")
+        private String currentPassword;
+
+        @NotBlank(message = "newPassword는 필수값입니다")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$",
+                message = "비밀번호는 '숫자', '문자', '특수문자'를 최소 1개 이상 포함하며, 8자에서 16자까지 허용됩니다.")
+        private String newPassword;
+
+        public UserCommand.ModifyUserRequest toCommand() {
+            return UserCommand.ModifyUserRequest.builder()
+                    .loginId(loginId)
+                    .nickname(nickname)
+                    .currentPassword(currentPassword)
+                    .newPassword(newPassword)
+                    .build();
+
+        }
+    }
+
+    @Getter
+    @ToString
+    public static class ModifyUserResponse {
+        private final String loginId;
+        private final String email;
+        private final String nickname;
+        private final String password;
+        private final Role role;
+        private final LocalDate registrationDate;
+
+        public ModifyUserResponse(UserInfo userInfo) {
+            this.loginId = userInfo.getLoginId();
+            this.email = userInfo.getEmail();
+            this.nickname = userInfo.getNickname();
+            this.password = userInfo.getPassword();
+            this.role = userInfo.getRole();
+            this.registrationDate = userInfo.getRegistrationDate();
+        }
+    }
+
+
 }


### PR DESCRIPTION
Description:
Why
유저 정보를 수정하는 기능이 필요했으나 기존 코드에 구현되어 있지 않았음. 이를 추가하여 사용자 정보 관리의 편의성을 높이고자 함.

What
유저 정보 수정 기능 구현.
사용자 이름, 이메일 등의 기본 정보를 업데이트하는 API 추가.
단, 유저 세션 업데이트 기능은 아직 구현되지 않음. 해당 기능은 추후 작업 예정.

How
로컬 환경에서 테스트 완료.